### PR TITLE
fix: Resolve Vercel function size limit error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@ httpx==0.27.2
 fastf1[redis]==3.4.0
 pandas==2.2.2
 redis==5.0.7
-gunicorn

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,10 @@
 {
   "version": 2,
+  "functions": {
+    "api/index.py": {
+      "excludeFiles": "{.fastf1-cache/**, .github/**, .venv/**, app/**}"
+    }
+  },
   "builds": [
     {
       "src": "api/index.py",


### PR DESCRIPTION
This commit fixes the 'Serverless Function has exceeded the unzipped maximum size of 250 MB' error that occurred during Vercel deployment.

Two optimizations were made:
1. The `gunicorn` package was removed from `requirements.txt` as it is not needed in Vercel's serverless runtime environment.
2. The `vercel.json` file was updated to include an `excludeFiles` rule for the Python function. This prevents large, non-runtime directories (such as the frontend `app`, `.venv`, and caches) from being bundled into the serverless function, drastically reducing its size.