### PR TITLE
fix: Correct vercel.json structure

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,14 +1,12 @@
 {
   "version": 2,
-  "functions": {
-    "api/index.py": {
-      "excludeFiles": "{.fastf1-cache/**, .github/**, .venv/**, app/**}"
-    }
-  },
   "builds": [
     {
       "src": "api/index.py",
-      "use": "@vercel/python"
+      "use": "@vercel/python",
+      "config": {
+        "excludeFiles": "{.fastf1-cache/**, .github/**, .venv/**, app/**}"
+      }
     },
     {
       "src": "app/package.json",


### PR DESCRIPTION
This commit corrects the structure of the vercel.json file to resolve a configuration error reported by Vercel.

The top-level `functions` property, which cannot be used in conjunction with the `builds` property, has been removed.

The `excludeFiles` rule has been correctly moved into the `config` object of the Python function's build definition within the `builds` array.